### PR TITLE
Add Derive4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A list of awesome frameworks, libraries and software that is powered by Javaslan
     - [javaslang-jackson](#javaslang-jackson)
     - [javaslang-circuitbreaker](#javaslang-circuitbreaker)
     - [cyclops-javaslang](#cyclops-javaslang)
+    - [derive4j](#derive4j)
     - [micro-javaslang](#micro-javaslang)
 - [Contributing](#contributing)
 
@@ -20,6 +21,10 @@ A lightweight, easy-to-use fault tolerance library designed for Java8 and functi
 ## [cyclops-javaslang](https://github.com/aol/cyclops/tree/master/cyclops-javaslang)
 
 for-comprehensions, Streaming Utilities, type conversions, Memoization with pluggable caches & more.
+
+## [derive4j](https://github.com/derive4j/derive4j)
+
+Code generator for user-defined algebraic datatypes (aka sum types). Structural pattern matching, laziness, functional setters, catamorphisms & more. With special support for javaslang through the ```Javaslang``` [flavour](https://github.com/derive4j/derive4j#flavours).
 
 ## [micro-javaslang](https://github.com/aol/micro-server/tree/master/micro-javaslang)
 


### PR DESCRIPTION
Javaslang is now supported as a derive4j flavour (since 0.6).
You may even use it in the javaslang code base (with a compile only dependency) :smile: 